### PR TITLE
Attempt to package for ManyLinux1 with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# Travis CI script based on https://github.com/pypa/python-manylinux-demo
+
+notifications:
+  email: false
+
+matrix:
+  include:
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+           PLAT=manylinux1_x86_64
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
+           PRE_CMD=linux32
+           PLAT=manylinux1_i686
+    - sudo: required
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
+           PLAT=manylinux2010_x86_64
+
+install:
+  - docker pull $DOCKER_IMAGE
+
+script:
+  - docker run --rm -e PLAT=$PLAT -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/contrib/travis-ci/build-wheels.sh
+  - ls -l wheelhouse/arpa2shell*

--- a/contrib/travis-ci/build-wheels.sh
+++ b/contrib/travis-ci/build-wheels.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Script based on https://github.com/pypa/python-manylinux-demo
+
+set -e -x
+
+# Install system packages required by our libraries
+#NONEED# yum search ldap
+#NONEED# yum search gssapi
+#NONEED# yum search riak
+#NONEED# yum install -y gssapi openldap
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    # "${PYBIN}/pip" install -r /io/dev-requirements.txt
+    "${PYBIN}/pip" wheel /io/ -w /io/wheelhouse/
+done
+
+# Show where the intermediates have gone
+echo Show where the intermediates have gone
+ls -l /io/wheelhouse/
+
+# Bundle external shared libraries into the wheels
+for whl in /io/wheelhouse/*.whl; do
+    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
+done
+
+# Show where the output has gone
+echo Show where the output has gone
+ls -l /io/wheelhouse/
+
+# Install packages and test
+for PYBIN in /opt/python/*/bin/; do
+    "${PYBIN}/pip" install arpa2shell --no-index -f /io/wheelhouse
+    #TODO:TRYIT# (cd "$HOME"; "${PYBIN}/nosetests" pymanylinuxdemo)
+done

--- a/subsetup.py
+++ b/subsetup.py
@@ -8,65 +8,6 @@ from os import path
 here = path.dirname (path.realpath (__file__))
 
 
-#
-# Packaging Instructions -- arpa2shell.cmd, .cmdparser, .amqp
-#
-readme = open (path.join (here, 'README.MD')).read ()
-setuptools.setup (
-
-	# What?
-	name = 'arpa2shell',
-	version = '0.0.0',
-	url = 'https://github.com/arpa2/arpa2shell',
-	description = 'The ARPA2 Shell Collection',
-	long_description = readme,
-	long_description_content_type = 'text/markdown',
-
-	# Who?
-	author = 'Rick van Rein (for the ARPA2 Project)',
-	author_email = 'rick@openfortress.nl',
-
-	# Where?
-	namespace_packages = [ 'arpa2shell', ],
-	packages = [
-		'arpa2shell',
-		'arpa2shell.cmdshell',
-		'arpa2shell.cmdparser',
-		'arpa2shell.amqp',
-	],
-	package_dir = {
-		'arpa2shell'           : path.join (here, 'src'),
-		'arpa2shell.cmdshell'  : path.join (here, 'src', 'cmdshell'),
-		'arpa2shell.cmdparser' : path.join (here, 'src', 'cmdparser'),
-		'arpa2shell.amqp'      : path.join (here, 'src', 'amqp'),
-	},
-
-	# How?
-	entry_points = {
-		'arpa2shell.cmdshell.subclasses' : [
-			'arpa2shell=arpa2shell.cmdshell.meta:Cmd',
-		],
-		'console_scripts' : [
-			'arpa2shell=arpa2shell.cmdshell.meta:main',
-			'arpa2client=arpa2shell.amqp.client:main [JSON]',
-			'arpa2server=arpa2shell.amqp.server:main [JSON]',
-		],
-	},
-
-	# Requirements
-	install_requires = [ 'enum34', 'six', 'decorator' ],
-	extras_require = {
-		'JSON' : [ 'gssapi', 'python-qpid-proton' ],
-	},
-
-)
-
-
-#TODO# For now, just build the main shell
-#TODO# Travis CI builds through "pip whell" which breaks otherwise
-import sys
-sys.exit (0)
-
 
 #
 # Additional setup -- for the arpa2dns shell


### PR DESCRIPTION
 - Load a ManyLinux1 environment from quai.io
 - Run "pip wheel" on many Python versions
 - Binary libraries are all very old / compatible
 - Scrubbed results are delivered, ready for PyPi
 - See https://github.com/pypa/python-manylinux-demo
 - Splitting setup.py may be necessary
 - Removed library installs (not needed)
 - Python3 tripped over a comma!
 - Changed the demo name to my installable
 - Changed location of final "ls" command
 - Listing /io/wheelhouse/
 - More explicit about output directory
 - More absolute paths to /io/wheelhouse/
 - Only the final command was failing, made inquiries
 - Listing just what matters
 - Whoa... we cannot output our build results?!?