### PR TITLE
Reservoir Shell: change Riak KV to Filesystem

### DIFF
--- a/src/arpa2dns/shell.py
+++ b/src/arpa2dns/shell.py
@@ -11,8 +11,7 @@ import uuid
 import string
 import re
 
-from arpa2shell import cmdshell
-from arpa2shell import cmdparser
+from arpa2shell import cmdshell, cmdparser
 
 import tightknot
 

--- a/src/arpa2reservoir/shell.py
+++ b/src/arpa2reservoir/shell.py
@@ -166,7 +166,9 @@ def fetch_domain_list ():
 		#DEBUG# print ('Query response:', qr1)
 		# Note that we always set a single associatedDomain
 		# but domainRelatedObject does not set it as SINGLE-VALUE
-		return [ at.get ('associatedDomain', ['undefined']) [0] for (dn,at) in qr1 ]
+		return [ str (at.get ('associatedDomain', ['(undefined)']) [0],
+		              'utf-8')
+		         for (dn,at) in qr1 ]
 	except NO_SUCH_OBJECT:
 		return []
 
@@ -216,7 +218,9 @@ def fetch_collection_list (domain):
 		#DEBUG# print ('Query response:', qr1)
 		# Note that we always set a single resins
 		# but domainRelatedObject does not set it as SINGLE-VALUE
-		return [ at.get ('resins', ['(undefined)']) [0] for (dn,at) in qr1 ]
+		return [ str (at.get ('resins', ['(undefined)']) [0],
+		              'utf-8')
+		         for (dn,at) in qr1 ]
 	except NO_SUCH_OBJECT:
 		return []
 
@@ -253,6 +257,7 @@ def fetch_index_list (dn1):
 	#DEBUG# print ('Query result:', qr1)
 	for (dn,at) in qr1:
 		for rr in at.get ('reservoirRef', []):
+			rr = str (rr, 'utf-8')
 			try:
 				[v,k] = rr.split (' ', 1)
 				rv1 [k] = v
@@ -322,7 +327,9 @@ def fetch_resource_list_by_dn (dn1):
 	#DEBUG# print ('Query response:', qr1)
 	# Treat the resource as SINGLE-VALUE
 	# as this is how we use it
-	return [ at.get ('resource', ['(undefined)']) [0] for (dn,at) in qr1 ]
+	return [ str (at.get ('resource', ['(undefined)']) [0],
+	              'utf-8')
+	         for (dn,at) in qr1 ]
 def fetch_resource_list (domain, colluuid):
 	dn1 = 'resins=' + colluuid + ',associatedDomain=' + domain + ',' + base
 	return fetch_resource_list_by_dn (dn1)
@@ -465,7 +472,7 @@ class Cmd (cmdshell.Cmd):
 			if self.cur_dn is not None:
 				print (self.cur_dn)
 			else:
-				print ('**undefined**')
+				print ('(undefined)')
 		elif args [1] == 'list':
 			if self.cur_dn is None:
 				print ('First use: index domain <domain> | collection <colluuid>')

--- a/src/arpa2reservoir/shell.py
+++ b/src/arpa2reservoir/shell.py
@@ -166,7 +166,7 @@ def fetch_domain_list ():
 		#DEBUG# print ('Query response:', qr1)
 		# Note that we always set a single associatedDomain
 		# but domainRelatedObject does not set it as SINGLE-VALUE
-		return [ str (at.get ('associatedDomain', ['(undefined)']) [0],
+		return [ str (at.get ('associatedDomain', [b'(undefined)']) [0],
 		              'utf-8')
 		         for (dn,at) in qr1 ]
 	except NO_SUCH_OBJECT:
@@ -218,7 +218,7 @@ def fetch_collection_list (domain):
 		#DEBUG# print ('Query response:', qr1)
 		# Note that we always set a single resins
 		# but domainRelatedObject does not set it as SINGLE-VALUE
-		return [ str (at.get ('resins', ['(undefined)']) [0],
+		return [ str (at.get ('resins', [b'(undefined)']) [0],
 		              'utf-8')
 		         for (dn,at) in qr1 ]
 	except NO_SUCH_OBJECT:
@@ -327,7 +327,7 @@ def fetch_resource_list_by_dn (dn1):
 	#DEBUG# print ('Query response:', qr1)
 	# Treat the resource as SINGLE-VALUE
 	# as this is how we use it
-	return [ str (at.get ('resource', ['(undefined)']) [0],
+	return [ str (at.get ('resource', [b'(undefined)']) [0],
 	              'utf-8')
 	         for (dn,at) in qr1 ]
 def fetch_resource_list (domain, colluuid):


### PR DESCRIPTION
There is no future for Riak KV, unfortunately.  The product was broken after Basho stopped functioning.

Instead, we shall now build `arpa2reservoir` on top of a file system (which may be exported from elsewhere) with a structure `/var/arpa2/reservoir/<domain>/<colluuid>/<resuuid>` instead of the object store of Riak KV.  When a cluster file system, or a pool like ZFS is used, similar effects can be had.

The `arpa2reservoir` now runs properly under Python3, with our upgrade to the `cmdparser` package.  We have not been able to get this to arrive at the original `cmdparser` package, which appears to be stuck in Python 2.7.  What a pitty, it is good enough to move on.  Note that we also added our JSON interface to this version, so it can be addressed over AMQP.