### PR TITLE
Working arpa2_acl

### DIFF
--- a/src/arpa2acl/shell.py
+++ b/src/arpa2acl/shell.py
@@ -251,8 +251,6 @@ class Cmd (cmdshell.Cmd):
 			raise Exception ('Format: acl_add %rights selector...')
 		rgt = words [0]
 		for sel in words [1:]:
-			if sel [:1] == '%':
-				sel = '%' + sel
 			self.cur_acl.selector_add (sel, rgt)
 
 	"""Remove selector.... regardless of its current rights from the ACL in LDAP."""

--- a/src/arpa2acl/shell.py
+++ b/src/arpa2acl/shell.py
@@ -115,8 +115,12 @@ class ACL ():
 			if qr1 == []:
 				raise NO_SUCH_OBJECT ()
 			[(dn1,at1)] = qr1
-			self.attr = at1
-			self.orig = at1.get ('acl', [])
+			self.attr = { }
+			for (k,vs) in at1.items ():
+				if type (k) == bytes:
+					k = str(k,'utf-8')
+				self.attr [k] = [ str(v,'utf-8') for v in vs ]
+			self.orig = self.attr.get ('acl', [])
 			for acl1 in self.orig:
 				rgt = None
 				for wrd1 in acl1.strip ().split ():
@@ -178,10 +182,10 @@ class ACL ():
 		#TODO# Maybe stupid: deleting everything and pushing it back is leads to more work downstream
 		mod = [ ]
 		for acl in self.orig:
-			mod.append ( (MOD_DELETE, 'acl', acl) )
+			mod.append ( (MOD_DELETE, 'acl', bytes(acl,'utf-8')) )
 		#TODO# Maybe stupid: one line would always change as a whole, leading to more work downstream
 		new = ' '.join (new)
-		mod.append ( (MOD_ADD,    'acl', new) )
+		mod.append ( (MOD_ADD,    'acl', bytes(new,'utf-8')) )
 		try:
 			print ('MOD =', mod)
 			dap.modify_s (self.dn, mod)


### PR DESCRIPTION
Python3 updates, bytes/strings, removed `%%` escape zeal, now edits nicely.

Typical use (note the generic nature of the commands):

```
acl_dn resins=0878c424-e544-43cd-b1c4-71f8c7f76237,associatedDomain=arpa2.org,ou=Reservoir,o=arpa2.net,ou=InternetWide
acl_add %r bakker@orvelte.nep
acl_del @arpa2.org
acl_save
```
